### PR TITLE
Replaces failure::*::Hash with std::hash::Hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2018"
 
 [dependencies]
 clap = "2"
-failure = "0.1"
 flate2 = { version = "1.0", features = ["cloudflare_zlib"], default-features = false }
 rio_api = "0.5"
 rio_turtle = "0.5"

--- a/src/multimap.rs
+++ b/src/multimap.rs
@@ -1,6 +1,4 @@
-use failure::_core::hash::Hash;
-use std::collections::HashMap;
-use std::iter::FromIterator;
+use std::{collections::HashMap, hash::Hash, iter::FromIterator};
 
 /// A multimap data structure that associate to each key a set of values
 /// The methods are similar to the Rust std::collections::HashMap


### PR DESCRIPTION
I hope I didn't get it wrong, but there is a Hash trait from the failure crate included that just exposes Rust core functionality so I removed the failure crate from the Cargo.toml and used the std:: one as there was no other usage for failure.


https://doc.rust-lang.org/nightly/core/hash/trait.Hash.html#tymethod.hash
https://docs.rs/failure/0.1.8/failure/struct.Compat.html#method.hash